### PR TITLE
The namespace issue is fixed.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,5 @@
 group 'io.flutterfastkit.fk_user_agent'
+
 version '2.0.0'
 
 buildscript {
@@ -24,6 +25,10 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 30
 
+    if (project.android.hasProperty("namespace")) {
+        namespace = group
+    }
+
     defaultConfig {
         minSdkVersion 16
     }
@@ -32,3 +37,17 @@ android {
         disable 'InvalidPackage'
     }
 }
+
+task setupManifest {
+    doLast {
+        def manifestFile = file("$projectDir/src/main/AndroidManifest.xml")
+        if (project.android.hasProperty("namespace")) {
+            manifestFile.text = "<manifest />"
+        } else {
+            manifestFile.text = "<manifest package=\"${project["group"]}\" />"
+        }
+    }
+}
+
+preBuild.dependsOn(setupManifest)
+

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.flutterfastkit.fk_user_agent">
-</manifest>
+<manifest />


### PR DESCRIPTION
Added conditional setup of the namespace and package name for different versions of the Gradle:

- if the Gradle has a namespace feature: set namespace in the build.gradle and remove a package from the AndroidManifest

- if the Gradle does not have a namespace feature: do not set the namespace in the build.gradle and set a package in the AndroidManifest
